### PR TITLE
Fix leak when AudioFileGetProperty() failed in [CoreAudioDecoder imageDataFromID3Tag:]

### DIFF
--- a/OrigamiEngine/Plugins/CoreAudioDecoder.m
+++ b/OrigamiEngine/Plugins/CoreAudioDecoder.m
@@ -259,6 +259,7 @@
             rawID3Tag);
 
     if (err != noErr) {
+        free(rawID3Tag);
         return nil;
     }
 


### PR DESCRIPTION
Saw Instrument complaint it.
