### PR TITLE
Fixes an issue when partially playing 120+ local files breaks Origami En...

### DIFF
--- a/OrigamiEngine/ORGMEngine.m
+++ b/OrigamiEngine/ORGMEngine.m
@@ -212,4 +212,14 @@
     [_output setVolume:volume];
 }
 
+- (void)setInput:(ORGMInputUnit *)input
+{
+    if (_input != input) {
+        ORGMInputUnit *previousInput = _input;
+        _input = [input retain];
+        [previousInput close];
+        [previousInput release];
+    }
+}
+
 @end


### PR DESCRIPTION
...gine

(`close` method was never called for `ORGMInputUnit`s (therefore for its decoder's source) so after "skipping trough" a lot of local files we get "too many open files" error)
