### PR TITLE
Remove method changing format of stream which in output scope and who…

### DIFF
--- a/OrigamiEngine/ORGMOutputUnit.m
+++ b/OrigamiEngine/ORGMOutputUnit.m
@@ -106,12 +106,6 @@
 - (void)setSampleRate:(double)sampleRate {
     UInt32 size = sizeof(AudioStreamBasicDescription);
     _format.mSampleRate = sampleRate;
-    AudioUnitSetProperty(outputUnit,
-                         kAudioUnitProperty_StreamFormat,
-                         kAudioUnitScope_Output,
-                         0,
-                         &_format,
-                         size);
 
     AudioUnitSetProperty(outputUnit,
                          kAudioUnitProperty_StreamFormat,
@@ -215,12 +209,6 @@ static OSStatus Sound_Renderer(void *inRefCon,
         deviceFormat.mBitsPerChannel = 24;
     }
 
-    AudioUnitSetProperty(outputUnit,
-            kAudioUnitProperty_StreamFormat,
-            kAudioUnitScope_Output,
-            0,
-            &deviceFormat,
-            size);
     AudioUnitSetProperty(outputUnit,
             kAudioUnitProperty_StreamFormat,
             kAudioUnitScope_Input,


### PR DESCRIPTION
Thanks you for very nice library :)
I found a bug about FLAC.
So I report it to you.(Sorry about my poor English.)

I think,format of stream that is in output scope and whose element is zero is from the currently-active output audio hardware.
So we cannot change its format and return kAudioUnitErr_PropertyNotWritable.
This error affect changing another stream format.

Please look the section,”Essential Characteristics of I/O Units”.
(https://developer.apple.com/library/ios/documentation/MusicAudio/Conceptual/AudioUnitHostingGuide_iOS/AudioUnitHostingFundamentals/AudioUnitHostingFundamentals.html)
