### PR TITLE
Fixed return of a cover into result.

### DIFF
--- a/OrigamiEngine.podspec
+++ b/OrigamiEngine.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name                  = "OrigamiEngine"
-  s.version               = "1.0.14"
+  s.version               = "1.0.14.1"
   s.summary               = "Lightweight iOS/OSX audio engine with flac, cue, mp3, m4a, m3u support."
-  s.homepage              = "https://github.com/ap4y/OrigamiEngine.git"
+  s.homepage              = "https://github.com/delitestudio/OrigamiEngine.git"
   s.license               = 'MIT'
   s.author                = { "ap4y" => "lod@pisem.net" }
-  s.source                = { :git => "https://github.com/ap4y/OrigamiEngine.git", :tag => "1.0.14", :submodules => true }
+  s.source                = { :git => "https://github.com/delitestudio/OrigamiEngine.git", :tag => "1.0.14.1", :submodules => true }
   s.default_subspec       = 'Core'
   s.requires_arc          = false
   s.ios.deployment_target = '5.0'

--- a/OrigamiEngine/Plugins/CoreAudioDecoder.m
+++ b/OrigamiEngine/Plugins/CoreAudioDecoder.m
@@ -243,12 +243,12 @@ const int ID3V1_SIZE = 128;
                              &dataSize,
                              &image);
         if (image) {
-            [self.metadata setObject:image forKey:@"picture"];
+            [result setObject:image forKey:@"picture"];
             CFRelease(image);
         }
 
     } else if ((image = [self imageDataFromID3Tag:audioFile])) {
-        [self.metadata setObject:image forKey:@"picture"];
+        [result setObject:image forKey:@"picture"];
     }
 
     return result;


### PR DESCRIPTION
Function `metadataForFile` does not return cover pictures, they where set directly into `self.metadata`. This will cause cover pictures being lost where the result of `metadataForFile` is assigned back to `self.metadata`.