### PR TITLE
Fix crash when image AudioFormatGetProperty returns with error

### DIFF
--- a/OrigamiEngine/Plugins/CoreAudioDecoder.m
+++ b/OrigamiEngine/Plugins/CoreAudioDecoder.m
@@ -284,11 +284,15 @@ const int ID3V1_SIZE = 128;
             &id3TagSize);
 
     CFDictionaryRef id3Dict;
-    AudioFormatGetProperty(kAudioFormatProperty_ID3TagToDictionary,
+    int success = AudioFormatGetProperty(kAudioFormatProperty_ID3TagToDictionary,
             propertySize,
             rawID3Tag,
             &id3TagSize,
             &id3Dict);
+
+    if (success != noErr) {
+      return nil;
+    }
 
     NSDictionary *tagDict = [NSDictionary dictionaryWithDictionary:(NSDictionary *)id3Dict];
     free(rawID3Tag);


### PR DESCRIPTION
The block of code patched fixes a crash when trying to retrieve an image property that returns with an error.